### PR TITLE
allow for Linewise Rouge formatter

### DIFF
--- a/lib/middleman-syntax/formatters.rb
+++ b/lib/middleman-syntax/formatters.rb
@@ -12,6 +12,8 @@ module Middleman
                        end
 
           @formatter = Rouge::Formatters::HTMLTable.new(@formatter, opts) if opts[:line_numbers]
+        
+          @formatter = Rouge::Formatters::HTMLLinewise.new(@formatter, class='line-%i') if opts[:line_numbers_div]
 
           if opts.fetch(:wrap, true)
             @formatter = Rouge::Formatters::HTMLPygments.new(@formatter, opts.fetch(:css_class, 'codehilite'))


### PR DESCRIPTION
Rouge can produce an output with divs around each line. This allows you to select that as an option.